### PR TITLE
[FEAT] 창문 로띠뷰에서 음성인식 뷰로 넘어가는 기능

### DIFF
--- a/Codingdong-iOS/Codingdong-iOS/Presentation/SM_Concept2/ViewController/WindowHoleViewController.swift
+++ b/Codingdong-iOS/Codingdong-iOS/Presentation/SM_Concept2/ViewController/WindowHoleViewController.swift
@@ -52,6 +52,12 @@ final class WindowHoleViewController: UIViewController, ConfigUI {
         return view
     }()
     
+    private let nextButton = CommonButton()
+    
+    private lazy var nextButtonViewModel = CommonbuttonModel(title: "다음",font: FontManager.textbutton(), titleColor: .primary1, backgroundColor: .primary2) { [weak self] in
+        self?.navigationController?.pushViewController(WindowVoiceViewController(), animated: false)
+    }
+    
     // MARK: - View init
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -61,6 +67,8 @@ final class WindowHoleViewController: UIViewController, ConfigUI {
         setConstraints()
         setupAccessibility()
         setGestureRecognizer()
+        nextButton.isHidden = true
+        nextButton.setup(model: nextButtonViewModel)
     }
     
     func setupNavigationBar() {
@@ -83,7 +91,7 @@ final class WindowHoleViewController: UIViewController, ConfigUI {
     }
     
     func addComponents() {
-        [titleLabel, windowImageView, tigerHandHoleAnimationView, tigerNoseHoleAnimationView, tigerTailHoleAnimationView].forEach {
+        [titleLabel, windowImageView, tigerHandHoleAnimationView, tigerNoseHoleAnimationView, tigerTailHoleAnimationView, nextButton].forEach {
             view.addSubview($0)
         }
     }
@@ -123,6 +131,13 @@ final class WindowHoleViewController: UIViewController, ConfigUI {
             $0.right.equalTo(windowImageView.snp.right).offset(-75)
             $0.bottom.equalTo(windowImageView.snp.bottom).offset(-88)
         }
+        
+        nextButton.snp.makeConstraints {
+            $0.left.equalToSuperview().offset(Constants.Button.buttonPadding)
+            $0.right.equalToSuperview().offset(-Constants.Button.buttonPadding)
+            $0.bottom.equalToSuperview().offset(-Constants.Button.buttonPadding * 2)
+            $0.height.equalTo(72)
+        }
     }
     
     func setupAccessibility() {
@@ -150,6 +165,7 @@ extension WindowHoleViewController {
     
     @objc 
     func viewTapped(_ sender: UITapGestureRecognizer) {
+        self.nextButton.isHidden = false
         if let type = AnimationType(rawValue: sender.view?.tag ?? 1) {
             switch type {
             case .hand:


### PR DESCRIPTION
<!--제목 작성 방법 -->
<!--[FEAT/SETTING/DESIGN/FIX/REFACTOR/DOCS] 관련 내용 기재 -->

## 🛠️ 작업 내용

<!-- - #이슈번호 -->
- #94 

<br/>

## 👀 소개

<!-- 구현된 내용(스샷 포함), 사용법, 참고 자료, 함께 논의하고 싶은 내용 등을 자유롭게 기재 -->
로띠뷰에서 로띠가 하나라도 실행되면 다음으로 넘어가는 버튼이 활성화 되도록 했습니다.


<br/>

## ✋ 잠깐만! 자가 체크

- [x]  나는 올바른 브랜치에서 작업했나요?
- [x]  머지하려는 브랜치의 방향이 정확한가요? 혹쉬 지금 main으로 머지하려던 건 아니겠죠?
- [x]  PR에 내가 작업한 내용을 모두 기재했나요? 설마 귀찮다고 그냥 넘어가려던 건 아니겠죠?
- [x]  스스로 self-review는 했나요?
- [x]  내 코드에 대한 책임은 나에게 있다! PR 보냈다고 끝이 아니란 사실, 이미 잘 알고 있죠?
