### PR TITLE
[FIX] STT 뷰, 떡 주기 뷰 보이스오버 픽스

### DIFF
--- a/Codingdong-iOS/Codingdong-iOS/Presentation/SM_Concept1/ViewController/GiveTtekkViewController.swift
+++ b/Codingdong-iOS/Codingdong-iOS/Presentation/SM_Concept1/ViewController/GiveTtekkViewController.swift
@@ -148,15 +148,15 @@ extension GiveTtekkViewController {
         guard let poppedView = ttekks.last else {
             self.hapticManager?.playSplash()
             self.nextButton.isHidden = false
-            let newText = """
+            self.storyLabel.text = """
                         호랑이는 떡을 먹고도 아직 배가 고픈가봐요.
                             
                         이제는 떡이 더이상 없는데 어떡하죠?
                             
                         배고픈 호랑이가 엄마를 무섭게 노려보고 있어요.
                         """
-            self.storyLabel.text = newText
-            UIAccessibility.post(notification: .layoutChanged, argument: "왜 안읽지")
+            
+            UIAccessibility.post(notification: .layoutChanged, argument: self.storyLabel)
             return
         }
         


### PR DESCRIPTION
<!--제목 작성 방법 -->
<!--[FEAT/SETTING/DESIGN/FIX/REFACTOR/DOCS] 관련 내용 기재 -->

## 🛠️ 작업 내용
- #99 
- #98 에서 언급한 '떡 주기 화면의 텍스트 업데이트 시 포커스만 잡아주고 읽어주지 않음' 문제 해결
<!-- - #이슈번호 -->


<br/>

## STT 뷰 픽스
- 카운트 다운에 보이스 오버가 적용이 되지 않는 것을 `DispatchQueue` 와 코드 리팩토링을 통해 해결했습니다.
- 타이머 작동 시 최초 1회 인터벌 후 동작이 들어가기 때문에, `titleLabel` 초기값을 `"\(3)"` 으로, `initialCountNumber` 는 2로 조정했습니다.
- 'titleLabel' 의 경우 `viewDidLoad` 에서 읽히기 때문에, 초기화에 `0.3초` 의 딜레이를 줬습니다.
- 앞뒤로 인터벌을 조절해서 실제 귀에 들리기에는 일정한 간격으로 카운트 다운 되도록 픽스 했습니다.

<br/>

## 떡 주기 뷰 픽스 
- #98  문제 해결의 경우 `UIAccessibility.post` 에 대한 이해 부족으로, 이전 커밋으로 롤백하여 문제 해결했습니다.

<!-- 구현된 내용(스샷 포함), 사용법, 참고 자료, 함께 논의하고 싶은 내용 등을 자유롭게 기재 -->

<br/>

## ✋ 잠깐만! 자가 체크

- [x]  나는 올바른 브랜치에서 작업했나요?
- [x]  머지하려는 브랜치의 방향이 정확한가요? 혹쉬 지금 main으로 머지하려던 건 아니겠죠?
- [x]  PR에 내가 작업한 내용을 모두 기재했나요? 설마 귀찮다고 그냥 넘어가려던 건 아니겠죠?
- [x]  스스로 self-review는 했나요?
- [x]  내 코드에 대한 책임은 나에게 있다! PR 보냈다고 끝이 아니란 사실, 이미 잘 알고 있죠?
