### PR TITLE
[FEAT] 전래 동화 모델에 SwiftData 적용

### DIFF
--- a/Codingdong-iOS/Codingdong-iOS.xcodeproj/project.pbxproj
+++ b/Codingdong-iOS/Codingdong-iOS.xcodeproj/project.pbxproj
@@ -85,6 +85,7 @@
 		A80B882A2ADB9A2400091FF5 /* RxRelay in Frameworks */ = {isa = PBXBuildFile; productRef = A80B88292ADB9A2400091FF5 /* RxRelay */; };
 		A80B883C2ADBA3EC00091FF5 /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = A80B883B2ADBA3EC00091FF5 /* .swiftlint.yml */; };
 		A81637242ADFC5FD0070DAC9 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = A81637232ADFC5FD0070DAC9 /* Constants.swift */; };
+		A827FA252B0DB36300E6B7B8 /* FableDBService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A827FA242B0DB36300E6B7B8 /* FableDBService.swift */; };
 		A828A66B2AFF05DB00B11D71 /* CardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A828A66A2AFF05DB00B11D71 /* CardView.swift */; };
 		A832B11A2AFF43E500E1CE9B /* YugwaList.swift in Sources */ = {isa = PBXBuildFile; fileRef = A832B1192AFF43E500E1CE9B /* YugwaList.swift */; };
 		A833929F2ADAB35D009BA7E2 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A833929E2ADAB35D009BA7E2 /* AppDelegate.swift */; };
@@ -197,6 +198,7 @@
 		A80A05342AFFCE9C00624BBC /* MyBookShelfViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyBookShelfViewModel.swift; sourceTree = "<group>"; };
 		A80B883B2ADBA3EC00091FF5 /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
 		A81637232ADFC5FD0070DAC9 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
+		A827FA242B0DB36300E6B7B8 /* FableDBService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FableDBService.swift; sourceTree = "<group>"; };
 		A828A66A2AFF05DB00B11D71 /* CardView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CardView.swift; sourceTree = "<group>"; };
 		A832B1192AFF43E500E1CE9B /* YugwaList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YugwaList.swift; sourceTree = "<group>"; };
 		A833929B2ADAB35D009BA7E2 /* Codingdong-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Codingdong-iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -535,6 +537,14 @@
 			path = Components;
 			sourceTree = "<group>";
 		};
+		A827FA232B0DB33700E6B7B8 /* Data */ = {
+			isa = PBXGroup;
+			children = (
+				A827FA242B0DB36300E6B7B8 /* FableDBService.swift */,
+			);
+			path = Data;
+			sourceTree = "<group>";
+		};
 		A828A6692AFF054800B11D71 /* SM_Concept1 */ = {
 			isa = PBXGroup;
 			children = (
@@ -580,6 +590,7 @@
 			children = (
 				A80B882B2ADB9A8400091FF5 /* Application */,
 				A8BC0DB02AE33FBB00AD5C9A /* Model */,
+				A827FA232B0DB33700E6B7B8 /* Data */,
 				A80B882E2ADB9ABC00091FF5 /* Presentation */,
 				A80B882C2ADB9A9800091FF5 /* Util */,
 			);
@@ -1011,6 +1022,7 @@
 				A80A05352AFFCE9C00624BBC /* MyBookShelfViewModel.swift in Sources */,
 				A8C00F842B021A8200201EAD /* SunMoonOnuiiViewController.swift in Sources */,
 				67816A4A2AE26FEF00B121B6 /* GiveTtekkViewController.swift in Sources */,
+				A827FA252B0DB36300E6B7B8 /* FableDBService.swift in Sources */,
 				A8C966F02B011914005105E8 /* CustomCollectionViewFlowLayout.swift in Sources */,
 				67BAECF12B000446006FB6D3 /* TigerHandHoleAnimationView.swift in Sources */,
 				67816A4A2AE26FEF00B121B6 /* GiveTtekkViewController.swift in Sources */,

--- a/Codingdong-iOS/Codingdong-iOS.xcodeproj/project.pbxproj
+++ b/Codingdong-iOS/Codingdong-iOS.xcodeproj/project.pbxproj
@@ -1211,7 +1211,7 @@
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1245,7 +1245,7 @@
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/Codingdong-iOS/Codingdong-iOS.xcodeproj/project.pbxproj
+++ b/Codingdong-iOS/Codingdong-iOS.xcodeproj/project.pbxproj
@@ -432,13 +432,6 @@
 			path = Manager;
 			sourceTree = "<group>";
 		};
-		11CB85DB2B069581008BA135 /* View */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = View;
-			sourceTree = "<group>";
-		};
 		11CD0ED92AFD568E00911B64 /* ViewController */ = {
 			isa = PBXGroup;
 			children = (
@@ -613,7 +606,6 @@
 		A852B1792B01F8810051BE9E /* SM_Concept3 */ = {
 			isa = PBXGroup;
 			children = (
-				11CB85DB2B069581008BA135 /* View */,
 				A8C00F7C2B01F9A100201EAD /* ViewModel */,
 				A852B17A2B01F88E0051BE9E /* ViewController */,
 			);

--- a/Codingdong-iOS/Codingdong-iOS/Data/FableDBService.swift
+++ b/Codingdong-iOS/Codingdong-iOS/Data/FableDBService.swift
@@ -9,7 +9,7 @@ import Foundation
 import SwiftData
 import Log
 
-class FableDBService {
+final class FableDBService {
     static var shared = FableDBService()
     var container: ModelContainer?
     var context: ModelContext?

--- a/Codingdong-iOS/Codingdong-iOS/Data/FableDBService.swift
+++ b/Codingdong-iOS/Codingdong-iOS/Data/FableDBService.swift
@@ -17,24 +17,22 @@ final class FableDBService {
     init() {
         do {
             container = try ModelContainer(for: FableData.self)
-            if let container {
-                context = ModelContext(container)
+            if let container { context = ModelContext(container) }
+            self.fetchFable { data, error in
+                if let error { Log.e(error) }
+                if data?.count == 0 { fables.forEach { self.context?.insert($0) } }
             }
-        } catch {
-            Log.e(error.localizedDescription)
-        }
+        } catch { Log.e(error.localizedDescription) }
     }
     
-    func fetchFable(onCompletion:@escaping([FableData]?, Error?) -> Void) {
+    func fetchFable(onCompletion: @escaping([FableData]?, Error?) -> Void) {
         let descriptor = FetchDescriptor<FableData>()
         
         if let context {
             do {
                 let data = try context.fetch(descriptor)
                 onCompletion(data,nil)
-            } catch {
-                onCompletion(nil,error)
-            }
+            } catch { onCompletion(nil,error) }
         }
     }
     

--- a/Codingdong-iOS/Codingdong-iOS/Data/FableDBService.swift
+++ b/Codingdong-iOS/Codingdong-iOS/Data/FableDBService.swift
@@ -1,0 +1,45 @@
+//
+//  FableDBService.swift
+//  Codingdong-iOS
+//
+//  Created by Joy on 11/22/23.
+//
+
+import Foundation
+import SwiftData
+import Log
+
+class FableDBService {
+    static var shared = FableDBService()
+    var container: ModelContainer?
+    var context: ModelContext?
+    
+    init() {
+        do {
+            container = try ModelContainer(for: FableData.self)
+            if let container {
+                context = ModelContext(container)
+            }
+        } catch {
+            Log.e(error.localizedDescription)
+        }
+    }
+    
+    func fetchFable(onCompletion:@escaping([FableData]?, Error?) -> Void) {
+        let descriptor = FetchDescriptor<FableData>()
+        
+        if let context {
+            do {
+                let data = try context.fetch(descriptor)
+                onCompletion(data,nil)
+            } catch {
+                onCompletion(nil,error)
+            }
+        }
+    }
+    
+    func updateFable(fable: FableData, checkRead: Bool) {
+        let readFable = fable
+        readFable.isRead = checkRead
+    }
+}

--- a/Codingdong-iOS/Codingdong-iOS/Model/Fable.swift
+++ b/Codingdong-iOS/Codingdong-iOS/Model/Fable.swift
@@ -18,3 +18,8 @@ class FableData {
         self.isRead = isRead
     }
 }
+
+
+let fables = [FableData(title: "해님달님", isRead: true),
+             FableData(title: "콩쥐팥쥐", isRead: false),
+             FableData(title: "별주부전", isRead: false)]

--- a/Codingdong-iOS/Codingdong-iOS/Model/Fable.swift
+++ b/Codingdong-iOS/Codingdong-iOS/Model/Fable.swift
@@ -6,18 +6,15 @@
 //
 
 import Foundation
+import SwiftData
 
-struct Fable {
+@Model
+class FableData {
+    @Attribute(.unique) var title: String
     var isRead: Bool
-    var title: String
+    
+    init(title: String, isRead: Bool) {
+        self.title = title
+        self.isRead = isRead
+    }
 }
-
-var fableList: [Fable] = [
-    Fable(isRead: true, title: "해님달님")
-//    ,
-//    Fable(isRead: false, title: "콩쥐팥쥐"),
-//    Fable(isRead: false, title: "별주부전"),
-//    Fable(isRead: false, title: "선녀와 나무꾼"),
-//    Fable(isRead: false, title: "금도끼 은도끼"),
-//    Fable(isRead: false, title: "심청전")
-]

--- a/Codingdong-iOS/Codingdong-iOS/Presentation/Opening/View/StoryListTableView.swift
+++ b/Codingdong-iOS/Codingdong-iOS/Presentation/Opening/View/StoryListTableView.swift
@@ -11,6 +11,7 @@ import Log
 final class StoryListTableView: UIView {
 
     var viewModel: MyBookShelfViewModelRepresentable?
+    var fableDataList = [FableData]()
     
     // TODO: Separator 오류 해결해야 함
     private lazy var storyListTableView: UITableView = {
@@ -26,35 +27,47 @@ final class StoryListTableView: UIView {
     
     override init(frame: CGRect) {
         super.init(frame: frame)
+        configUI()
+        fetchData()
+    }
     
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+    
+    func configUI() {
         addSubview(storyListTableView)
         storyListTableView.snp.makeConstraints {
             $0.left.top.right.bottom.equalToSuperview()
         }
         storyListTableView.register(StoryListTableViewCell.self, forCellReuseIdentifier: StoryListTableViewCell.identifier)
-        
     }
     
-    required init?(coder: NSCoder) {
-        super.init(coder: coder)
+    func fetchData() {
+        FableDBService.shared.fetchFable { data, error in
+            if let error { Log.e(error) }
+            if let data {
+                self.fableDataList = data
+                self.storyListTableView.reloadData()
+            }
+        }
     }
 }
 
 // MARK: - Extension
 extension StoryListTableView: UITableViewDataSource, UITableViewDelegate {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return fableList.count
+        return fableDataList.count
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         guard let cell = tableView.dequeueReusableCell(withIdentifier: StoryListTableViewCell.identifier , for: indexPath) as? StoryListTableViewCell else { fatalError() }
-        cell.model = fableList[indexPath.row]
+        cell.model = fableDataList[indexPath.row]
         return cell
     }
     
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        
-        if fableList[indexPath.row].title == "해님달님" {
+        if fableDataList[indexPath.row].title == "해님달님" {
             self.viewModel?.moveOn(.sunmoon)
         }
     }

--- a/Codingdong-iOS/Codingdong-iOS/Presentation/Opening/View/StoryListTableViewCell.swift
+++ b/Codingdong-iOS/Codingdong-iOS/Presentation/Opening/View/StoryListTableViewCell.swift
@@ -29,7 +29,7 @@ final class StoryListTableViewCell: UITableViewCell {
         return view
     }()
     
-    var model: Fable {
+    var model: FableData {
         didSet {
             isReadSymbolImage.image = model.isRead ? UIImage(systemName: "play.square") : UIImage(systemName: "lock.fill")
             titleLabel.text = model.title
@@ -63,7 +63,7 @@ final class StoryListTableViewCell: UITableViewCell {
     }()
     
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
-        self.model = Fable(isRead: false, title: "")
+        self.model = FableData(title: "", isRead: false)
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         addSubview(containerView)
         [isReadSymbolImage, titleLabel, isReadChevronImage].forEach { containerView.addSubview($0)

--- a/Codingdong-iOS/Codingdong-iOS/Presentation/Opening/ViewController/MyBookShelfViewController.swift
+++ b/Codingdong-iOS/Codingdong-iOS/Presentation/Opening/ViewController/MyBookShelfViewController.swift
@@ -176,7 +176,7 @@ final class MyBookShelfViewController: UIViewController, ConfigUI {
             $0.top.equalTo(storyTitle.snp.bottom).offset(16)
             $0.left.equalToSuperview().offset(16)
             $0.right.equalToSuperview().offset(-16)
-            $0.height.equalTo(60)
+            $0.height.equalTo(180)
         }
         
         cookieContainer.snp.makeConstraints {
@@ -200,6 +200,8 @@ final class MyBookShelfViewController: UIViewController, ConfigUI {
     }
     
     func fetchData() {
+        
+        
         if yugwaList.haveYugwa == false {
             innerLabel.isHidden = false
             innerView.isHidden = true


### PR DESCRIPTION
<!--제목 작성 방법 -->
<!--[FEAT/SETTING/DESIGN/FIX/REFACTOR/DOCS] 관련 내용 기재 -->

## 🛠️ 작업 내용

<!-- - #이슈번호 -->
- #56 

<br/>

## 👀 소개
<img width="244" alt="스크린샷 2023-11-22 오후 5 07 54" src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team5-COMBINE/assets/84610593/0297911f-1e31-4d1f-86cb-7207c1095695"> <br/>

- 전래 동화 리스트(해님달님, 콩쥐팥쥐, 별주부전) 용 모델 선언: `FableData`
- FableData와 관련해 데이터를 Read, Update 할 수 있는 `FableDBService` 생성
- `StoryListTableView`의 화면의 에서 Fetch 하도록 적용함

<br/>

## ✋ 잠깐만! 자가 체크
- [x]  나는 올바른 브랜치에서 작업했나요?
- [x]  머지하려는 브랜치의 방향이 정확한가요? 혹쉬 지금 main으로 머지하려던 건 아니겠죠?
- [x]  PR에 내가 작업한 내용을 모두 기재했나요? 설마 귀찮다고 그냥 넘어가려던 건 아니겠죠?
- [x]  스스로 self-review는 했나요?
- [x]  내 코드에 대한 책임은 나에게 있다! PR 보냈다고 끝이 아니란 사실, 이미 잘 알고 있죠?
