### PR TITLE
[FEAT] 챕터 2, 챕터 3, 복습 파트 보이스 오버 기능 개선

### DIFF
--- a/Codingdong-iOS/Codingdong-iOS/Presentation/Components/CardView.swift
+++ b/Codingdong-iOS/Codingdong-iOS/Presentation/Components/CardView.swift
@@ -66,8 +66,7 @@ final class CardView: UIView {
         addSubview(containerView)
         containerView.snp.makeConstraints {
             $0.top.bottom.equalToSuperview()
-            $0.left.equalToSuperview().offset(Constants.Button.buttonPadding)
-            $0.right.equalToSuperview().offset(-Constants.Button.buttonPadding)
+            $0.left.right.equalToSuperview().inset(Constants.Button.buttonPadding)
         }
         
         [titleLabel, separator, contentLabel, conceptImageView].forEach { containerView.addSubview($0) }

--- a/Codingdong-iOS/Codingdong-iOS/Presentation/Opening/ViewController/OnboardingViewController.swift
+++ b/Codingdong-iOS/Codingdong-iOS/Presentation/Opening/ViewController/OnboardingViewController.swift
@@ -62,6 +62,7 @@ final class OnboardingViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        view.backgroundColor = .gs90
         setupView()
         binding()
         setupAccessibility()

--- a/Codingdong-iOS/Codingdong-iOS/Presentation/SM_Concept1/ViewController/GiveTtekkViewController.swift
+++ b/Codingdong-iOS/Codingdong-iOS/Presentation/SM_Concept1/ViewController/GiveTtekkViewController.swift
@@ -46,7 +46,7 @@ final class GiveTtekkViewController: UIViewController, ConfigUI {
         label.font = FontManager.body()
         label.textColor = .gs10
         label.numberOfLines = 0
-        label.lineBreakMode = .byCharWrapping
+        label.lineBreakMode = .byWordWrapping
         return label
     }()
     

--- a/Codingdong-iOS/Codingdong-iOS/Presentation/SM_Concept1/ViewController/IfConceptViewController.swift
+++ b/Codingdong-iOS/Codingdong-iOS/Presentation/SM_Concept1/ViewController/IfConceptViewController.swift
@@ -58,12 +58,17 @@ final class IfConceptViewController: UIViewController, ConfigUI {
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .gs90
-        setupAccessibility()
         setupNavigationBar()
         addComponents()
         setConstraints()
         nextButton.setup(model: nextButtonViewModel)
         cardView.config(model: cardViewModel)
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        setupAccessibility()
+        navigationController?.navigationBar.accessibilityElementsHidden = true
     }
     
     func setupNavigationBar() {

--- a/Codingdong-iOS/Codingdong-iOS/Presentation/SM_Concept1/ViewController/TigerAnimationViewController.swift
+++ b/Codingdong-iOS/Codingdong-iOS/Presentation/SM_Concept1/ViewController/TigerAnimationViewController.swift
@@ -23,7 +23,7 @@ final class TigerAnimationViewController: UIViewController, ConfigUI {
         label.font = FontManager.body()
         label.textColor = .gs10
         label.numberOfLines = 0
-        label.lineBreakMode = .byCharWrapping
+        label.lineBreakMode = .byWordWrapping
         
         return label
     }()

--- a/Codingdong-iOS/Codingdong-iOS/Presentation/SM_Concept1/ViewController/TtekkkochiViewController.swift
+++ b/Codingdong-iOS/Codingdong-iOS/Presentation/SM_Concept1/ViewController/TtekkkochiViewController.swift
@@ -47,7 +47,7 @@ final class TtekkkochiViewController: UIViewController, ConfigUI {
         label.font = FontManager.body()
         label.textColor = .gs10
         label.numberOfLines = 0
-        label.lineBreakMode = .byCharWrapping
+        label.lineBreakMode = .byWordWrapping
         return label
     }()
     

--- a/Codingdong-iOS/Codingdong-iOS/Presentation/SM_Concept1/ViewController/TtekkkochiViewController.swift
+++ b/Codingdong-iOS/Codingdong-iOS/Presentation/SM_Concept1/ViewController/TtekkkochiViewController.swift
@@ -7,7 +7,6 @@
 
 import UIKit
 import Combine
-import Log
 
 final class TtekkkochiViewController: UIViewController, ConfigUI {
     var viewModel = TtekkkochiViewModel()
@@ -99,7 +98,6 @@ final class TtekkkochiViewController: UIViewController, ConfigUI {
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
         setupAccessibility()
-        Log.i("didLayout")
     }
     
     func setupNavigationBar() {
@@ -121,38 +119,33 @@ final class TtekkkochiViewController: UIViewController, ConfigUI {
     
     func setConstraints() {
         titleLabel.snp.makeConstraints {
-            $0.top.equalToSuperview().offset(122)
-            $0.left.equalToSuperview().offset(16)
-            $0.right.equalToSuperview().offset(-16)
+            $0.top.equalTo(naviLine.snp.bottom).offset(16)
+            $0.left.right.equalToSuperview().inset(16)
         }
         
         ttekkkochiCollectionView.snp.makeConstraints {
-            $0.top.equalTo(titleLabel.snp.bottom).offset(76)
-            $0.left.equalToSuperview().offset(95)
-            $0.right.equalToSuperview().offset(-95)
-            $0.bottom.equalToSuperview().offset(-226)
+            $0.top.equalTo(titleLabel.snp.bottom).offset(32)
+            $0.left.right.equalToSuperview().inset(95)
+            $0.bottom.equalTo(bottomView.snp.top).offset(-122)
         }
         
         stickView.snp.makeConstraints {
-            $0.top.equalTo(titleLabel.snp.bottom).offset(70)
-            $0.centerX.equalToSuperview()
-            $0.width.equalTo(8)
-            $0.bottom.equalTo(bottomView.snp.top).offset(-50)
+            $0.top.equalTo(titleLabel.snp.bottom).offset(28)
+            $0.left.right.equalToSuperview().inset(191)
+            $0.bottom.equalTo(bottomView.snp.top).offset(-72)
         }
         
         self.view.sendSubviewToBack(stickView)
         
         bottomView.snp.makeConstraints {
-            $0.left.equalToSuperview().offset(Constants.Button.buttonPadding)
-            $0.right.equalToSuperview().offset(-Constants.Button.buttonPadding)
-            $0.bottom.equalToSuperview().offset(-Constants.Button.buttonPadding * 2)
+            $0.left.right.equalToSuperview().inset(Constants.Button.buttonPadding)
+            $0.bottom.equalToSuperview().inset(Constants.Button.buttonPadding * 2)
             $0.height.equalTo(112)
         }
         
         nextButton.snp.makeConstraints {
-            $0.left.equalToSuperview().offset(Constants.Button.buttonPadding)
-            $0.right.equalToSuperview().offset(-Constants.Button.buttonPadding)
-            $0.bottom.equalToSuperview().offset(-Constants.Button.buttonPadding * 2)
+            $0.left.right.equalToSuperview().inset(Constants.Button.buttonPadding)
+            $0.bottom.equalToSuperview().inset(Constants.Button.buttonPadding * 2)
             $0.height.equalTo(72)
         }
     }

--- a/Codingdong-iOS/Codingdong-iOS/Presentation/SM_Concept2/View/TigerHandHoleAnimationView.swift
+++ b/Codingdong-iOS/Codingdong-iOS/Presentation/SM_Concept2/View/TigerHandHoleAnimationView.swift
@@ -14,6 +14,8 @@ final class TigerHandHoleAnimationView: UIView {
         let view = UIView()
         view.backgroundColor = .clear
         LottieManager.shared.setAnimationForWindow(named: "TigerHandHoleAnimation", inView: view)
+        view.isAccessibilityElement = true
+        view.accessibilityLabel = "두번째 구멍"
         return view
     }()
     

--- a/Codingdong-iOS/Codingdong-iOS/Presentation/SM_Concept2/View/TigerNoseHoleAnimationView.swift
+++ b/Codingdong-iOS/Codingdong-iOS/Presentation/SM_Concept2/View/TigerNoseHoleAnimationView.swift
@@ -14,6 +14,8 @@ final class TigerNoseHoleAnimationView: UIView {
         let view = UIView()
         view.backgroundColor = .clear
         LottieManager.shared.setAnimationForWindow(named: "TigerNoseHoleAnimation", inView: view)
+        view.isAccessibilityElement = true
+        view.accessibilityLabel = "첫번째 구멍"
         return view
     }()
     

--- a/Codingdong-iOS/Codingdong-iOS/Presentation/SM_Concept2/View/TigerTailHoleAnimationView.swift
+++ b/Codingdong-iOS/Codingdong-iOS/Presentation/SM_Concept2/View/TigerTailHoleAnimationView.swift
@@ -14,6 +14,8 @@ final class TigerTailHoleAnimationView: UIView {
         let view = UIView()
         view.backgroundColor = .clear
         LottieManager.shared.setAnimationForWindow(named: "TigerTailHoleAnimation", inView: view)
+        view.isAccessibilityElement = true
+        view.accessibilityLabel = "세번째 구멍"
         return view
     }()
     

--- a/Codingdong-iOS/Codingdong-iOS/Presentation/SM_Concept2/ViewController/AndConceptViewController.swift
+++ b/Codingdong-iOS/Codingdong-iOS/Presentation/SM_Concept2/ViewController/AndConceptViewController.swift
@@ -36,7 +36,7 @@ final class AndConceptViewController: UIViewController {
     
     private let titleLabel: UILabel = {
         let label = UILabel()
-        label.text = "해님달님의 두 번째 개념"
+        label.text = "두 번째 코딩 간식이야"
         label.font = FontManager.body()
         label.textColor = .gs10
         label.numberOfLines = 0
@@ -52,7 +52,7 @@ final class AndConceptViewController: UIViewController {
     
     private let cardView = CardView()
     
-    private let cardViewModel = CardViewModel(title: "그리고", content: "발톱, 꼬리 그리고 수염을 보고 호랑이임을 판단할 수 있었어요.", cardImage: "sm_concept2")
+    private let cardViewModel = CardViewModel(title: "그리고 과자", content: "호랑이의 발톱, 꼬리 그리고 수염을 보고 호랑이인 걸 알 수 있었어.", cardImage: "sm_concept2")
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -60,9 +60,14 @@ final class AndConceptViewController: UIViewController {
         setupNavigationBar()
         addComponents()
         setConstraints()
-        setupAccessibility()
         nextButton.setup(model: nextButtonViewModel)
         cardView.config(model: cardViewModel)
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        setupAccessibility()
+        navigationController?.navigationBar.accessibilityElementsHidden
     }
     
     func setupNavigationBar() {
@@ -85,28 +90,26 @@ final class AndConceptViewController: UIViewController {
     
     func setConstraints() {
         titleLabel.snp.makeConstraints {
-            $0.left.equalToSuperview().offset(basicPadding)
-            $0.right.equalToSuperview().offset(-basicPadding)
-            $0.top.equalTo(naviLine).offset(basicPadding)
+            $0.top.equalTo(naviLine.snp.bottom).offset(basicPadding)
+            $0.left.right.equalToSuperview().inset(basicPadding)
         }
         
         cardView.snp.makeConstraints {
             $0.top.equalTo(titleLabel.snp.bottom).offset(50)
             $0.left.right.equalToSuperview()
-            $0.bottom.equalToSuperview().offset(-142)
+            $0.bottom.equalToSuperview().inset(142)
         }
         
         nextButton.snp.makeConstraints {
-            $0.left.equalToSuperview().offset(basicPadding)
-            $0.right.equalToSuperview().offset(-basicPadding)
-            $0.bottom.equalToSuperview().offset(-basicPadding * 2)
+            $0.left.right.equalToSuperview().inset(basicPadding)
+            $0.bottom.equalToSuperview().inset(basicPadding * 2)
         }
     }
     
     func setupAccessibility() {
-        navigationItem.accessibilityElements = [leftBarButtonItem, navigationTitle]
-        view.accessibilityElements = [titleLabel, cardView, nextButton]
-        leftBarButtonItem.accessibilityLabel = "내 책장"
+        let leftBarButtonElement = setupLeftBackButtonItemAccessibility(label: "내 책장")
+        let naviTitleElement = setupNavigationTitleAccessibility(label: navigationTitle.text ?? "타이틀 없음")
+        view.accessibilityElements = [naviTitleElement, titleLabel, cardView, nextButton, leftBarButtonElement]
     }
 }
 

--- a/Codingdong-iOS/Codingdong-iOS/Presentation/SM_Concept2/ViewController/WindowEndingViewController.swift
+++ b/Codingdong-iOS/Codingdong-iOS/Presentation/SM_Concept2/ViewController/WindowEndingViewController.swift
@@ -53,7 +53,7 @@ final class WindowEndingViewController: UIViewController, ConfigUI {
         label.font = FontManager.body()
         label.textColor = .gs10
         label.numberOfLines = 0
-        label.lineBreakMode = .byCharWrapping
+        label.lineBreakMode = .byWordWrapping
         label.sizeToFit()
         return label
     }()

--- a/Codingdong-iOS/Codingdong-iOS/Presentation/SM_Concept2/ViewController/WindowEndingViewController.swift
+++ b/Codingdong-iOS/Codingdong-iOS/Presentation/SM_Concept2/ViewController/WindowEndingViewController.swift
@@ -7,14 +7,19 @@
 
 import UIKit
 import SnapKit
-import Log
 
 final class WindowEndingViewController: UIViewController, ConfigUI {
     
-    // TODO: isSuccess 값에 따라서 뷰가 바뀌지 않는 문제 해결 필요
-    // 나중에 @Published로 바꾸기, 지금은 일단 급함 ㅠㅠ
     private var isSuccessInt = UserDefaults.standard.integer(forKey: "key")
-    let titleLabelText: [String] = ["어맛, 호랑이에게 잡아먹혔어요. 다시 해 볼까요?", "호랑이를 본 오누이는 뒷문으로 도망쳤어요!"] // 0(열어줄래요), 1(싫어요)
+    let titleLabelText: [String] = [
+        """
+        아앗, 오누이가 호랑이한테 잡아먹히고 말았어.
+        다시 해 볼까?
+        """,
+        """
+        잘했어! 정답이야!
+        호랑이를 본 오누이는 무사히 뒷문으로 도망쳤어!
+        """]
     let imageName: [String] = ["tigerEatEnding", "initialDoor"]
     let buttonName: [String] = ["다시하기", "다음으로"]
     
@@ -44,28 +49,26 @@ final class WindowEndingViewController: UIViewController, ConfigUI {
     
     private lazy var titleLabel: UILabel = {
         let label = UILabel()
-        label.text = titleLabelText[isSuccessInt ?? 1]
+        label.text = titleLabelText[isSuccessInt]
         label.font = FontManager.body()
         label.textColor = .gs10
         label.numberOfLines = 0
         label.lineBreakMode = .byCharWrapping
+        label.sizeToFit()
         return label
     }()
     
     private lazy var imageView: UIImageView = {
         let imageView = UIImageView()
-        imageView.image = UIImage(named: imageName[isSuccessInt ?? 1])
+        imageView.image = UIImage(named: imageName[isSuccessInt])
         return imageView
     }()
     
     private let nextButton = CommonButton()
-    private lazy var settingButtonViewModel = CommonbuttonModel(title: buttonName[isSuccessInt ?? 1], font: FontManager.textbutton(), titleColor: .primary1, backgroundColor: .primary2) {[weak self] in
-        
-        // isSuccessInt == 1 - 탈출 성공
+    private lazy var settingButtonViewModel = CommonbuttonModel(title: buttonName[isSuccessInt], font: FontManager.textbutton(), titleColor: .primary1, backgroundColor: .primary2, height: 72) {[weak self] in
         if self?.isSuccessInt == 1 {
             self?.navigationController?.pushViewController(AndConceptViewController(), animated: false)
         } else {
-            // isSuccessInt == 0 - 탈출실패
             guard let viewControllerStack = self?.navigationController?.viewControllers else { return }
             for viewController in viewControllerStack {
                 if let startView = viewController as? WindowVoiceViewController {
@@ -82,7 +85,6 @@ final class WindowEndingViewController: UIViewController, ConfigUI {
         addComponents()
         setConstraints()
         setupAccessibility()
-        nextButton.setup(model: settingButtonViewModel)
     }
     
     func setupNavigationBar() {
@@ -101,34 +103,30 @@ final class WindowEndingViewController: UIViewController, ConfigUI {
         [titleLabel, imageView, nextButton].forEach {
             view.addSubview($0)
         }
+        nextButton.setup(model: settingButtonViewModel)
     }
     
     func setConstraints() {
         titleLabel.snp.makeConstraints {
-            $0.top.equalToSuperview().offset(122)
-            $0.left.equalToSuperview().offset(16)
-            $0.right.equalToSuperview().offset(-16)
+            $0.top.equalTo(naviLine.snp.bottom).offset(Constants.View.padding)
+            $0.left.right.equalToSuperview().inset(Constants.View.padding)
         }
         
         imageView.snp.makeConstraints {
-            $0.top.equalToSuperview().offset(222)
-            $0.bottom.equalToSuperview().offset(-152)
-            $0.left.equalToSuperview().offset(51)
-            $0.right.equalToSuperview().offset(-51)
+            $0.top.equalToSuperview().offset(256)
+            $0.left.right.equalToSuperview().inset(51)
+            $0.bottom.equalToSuperview().inset(118)
         }
         
         nextButton.snp.makeConstraints {
-            $0.left.equalToSuperview().offset(Constants.Button.buttonPadding)
-            $0.right.equalToSuperview().offset(-Constants.Button.buttonPadding)
-            $0.bottom.equalToSuperview().offset(-Constants.Button.buttonPadding * 2)
-            $0.height.equalTo(72)
+            $0.left.right.equalToSuperview().inset(Constants.Button.buttonPadding)
+            $0.bottom.equalToSuperview().inset(Constants.Button.buttonPadding * 2)
         }
     }
     
     func setupAccessibility() {
-        navigationItem.accessibilityElements = [leftBarButtonItem, navigationTitle]
-        view.accessibilityElements = [titleLabel, nextButton]
-        leftBarButtonItem.accessibilityLabel = "내 책장"
+        let leftBarButtonElement = setupLeftBackButtonItemAccessibility(label: "내 책장")
+        view.accessibilityElements = [titleLabel, nextButton, leftBarButtonElement]
     }
     
     @objc

--- a/Codingdong-iOS/Codingdong-iOS/Presentation/SM_Concept2/ViewController/WindowStartViewController.swift
+++ b/Codingdong-iOS/Codingdong-iOS/Presentation/SM_Concept2/ViewController/WindowStartViewController.swift
@@ -39,19 +39,18 @@ final class WindowStartViewController: UIViewController, ConfigUI {
     private let titleLabel: UILabel = {
         let label = UILabel()
         label.text = """
-        두번째 이야기
+        아직 배가 고픈 호랑이는 오누이도 잡아먹고 싶어졌어.
 
-        아직 배가 고픈 호랑이는 오누이도 잡아먹고 싶어졌어요.
+        그래서 엄마로 변장하는 꾀를 냈어.
+        
+        과연 오누이는 엄마로 변장한 호랑이를 알아차릴 수 있을까?
 
-        그래서 꾀를 내어 엄마로 변장해 오누이의 집으로 찾아갔어요.
-
-        오누이를 도와 문 밖의 무서운 호랑이의 정체를 밝혀볼까요?
+        오누이를 도와 문 밖의 무서운 호랑이의 정체를 밝혀보자!!
         """
-        label.translatesAutoresizingMaskIntoConstraints = false
         label.font = FontManager.body()
         label.textColor = .gs10
         label.numberOfLines = 0
-        label.lineBreakMode = .byCharWrapping
+        label.lineBreakMode = .byWordWrapping
         return label
     }()
     
@@ -65,11 +64,16 @@ final class WindowStartViewController: UIViewController, ConfigUI {
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .gs90
-        setupAccessibility()
         setupNavigationBar()
         addComponents()
         setConstraints()
         nextButton.setup(model: nextButtonViewModel)
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        setupAccessibility()
+        navigationController?.navigationBar.accessibilityElementsHidden = true
     }
     
     func setupNavigationBar() {
@@ -90,23 +94,21 @@ final class WindowStartViewController: UIViewController, ConfigUI {
     
     func setConstraints() {
         titleLabel.snp.makeConstraints {
-            $0.top.equalToSuperview().offset(122)
-            $0.left.equalToSuperview().offset(16)
-            $0.right.equalToSuperview().offset(-16)
+            $0.top.equalTo(naviLine.snp.bottom).offset(Constants.View.padding)
+            $0.left.right.equalToSuperview().inset(Constants.View.padding)
         }
         
         nextButton.snp.makeConstraints {
-            $0.left.equalToSuperview().offset(Constants.Button.buttonPadding)
-            $0.right.equalToSuperview().offset(-Constants.Button.buttonPadding)
-            $0.bottom.equalToSuperview().offset(-Constants.Button.buttonPadding * 2)
+            $0.left.right.equalToSuperview().inset(Constants.Button.buttonPadding)
+            $0.bottom.equalToSuperview().inset(Constants.Button.buttonPadding * 2)
             $0.height.equalTo(72)
         }
     }
     
     func setupAccessibility() {
-        navigationItem.accessibilityElements = [leftBarButtonItem, navigationTitle]
-        view.accessibilityElements = [titleLabel, nextButton]
-        leftBarButtonItem.accessibilityLabel = "내 책장"
+        let leftBarButtonElement = setupLeftBackButtonItemAccessibility(label: "내 책장")
+        let naviTitleElement = setupNavigationTitleAccessibility(label: navigationTitle.text ?? "타이틀 없음")
+        view.accessibilityElements = [naviTitleElement, titleLabel, nextButton, leftBarButtonElement]
     }
     
     @objc

--- a/Codingdong-iOS/Codingdong-iOS/Presentation/SM_Concept2/ViewController/WindowVoiceViewController.swift
+++ b/Codingdong-iOS/Codingdong-iOS/Presentation/SM_Concept2/ViewController/WindowVoiceViewController.swift
@@ -10,7 +10,7 @@ import SnapKit
 import Log
 
 final class WindowVoiceViewController: UIViewController, ConfigUI {
-    
+
     private let naviLine: UIView = {
         let view = UIView()
         view.backgroundColor = .white.withAlphaComponent(0.15)
@@ -38,15 +38,15 @@ final class WindowVoiceViewController: UIViewController, ConfigUI {
     private let titleLabel: UILabel = {
         let label = UILabel()
         label.text = """
-                    문 밖에 누가 있는지 확인했나요?
-                    
-                    문을 열어줄까요?
-                    '열어줄래요', '싫어요' 중에 대답해주세요.
+                    문 밖을 확인해보니 어때?
+                    엄마일까, 호랑이일까?
+                    문을 열어줘도 될까?
                     """
         label.font = FontManager.body()
         label.textColor = .gs10
         label.numberOfLines = 0
         label.lineBreakMode = .byCharWrapping
+        label.sizeToFit()
         return label
     }()
     
@@ -56,15 +56,24 @@ final class WindowVoiceViewController: UIViewController, ConfigUI {
         return imageView
     }()
     
-    private let speechButton = CommonButton()
-    private lazy var speechButtonViewModel = CommonbuttonModel(title: "누르고 말하기", font: FontManager.textbutton(), titleColor: .primary2, backgroundColor: .primary1) { [weak self] in
-            self?.navigationController?.pushViewController(WindowVoiceChildViewController(), animated: false)
+    private let yesButton = CommonButton()
+    private lazy var yesButtonViewModel = CommonbuttonModel(title: "열어줄래", font: FontManager.textbutton(), titleColor: .primary1, backgroundColor: .primary2, height: 72) { [weak self] in
+        UserDefaults.standard.set(0, forKey: "key")
+        self?.navigationController?.pushViewController(WindowEndingViewController(), animated: false)
     }
-    private let countdownBackgroundView: UIView = {
-        let view = UIView()
-        view.backgroundColor = .black.withAlphaComponent(0.5)
-        
-        return view
+    
+    private let noButton = CommonButton()
+    private lazy var noButtonViewModel = CommonbuttonModel(title: "안 열어줄래", font: FontManager.textbutton(), titleColor: .white, backgroundColor: .primary1, height: 72) { [weak self] in
+        UserDefaults.standard.set(1, forKey: "key")
+        self?.navigationController?.pushViewController(WindowEndingViewController(), animated: false)
+    }
+    
+    private let buttonHorizontalStack: UIStackView = {
+        let stack = UIStackView()
+        stack.axis = .horizontal
+        stack.spacing = 10
+        stack.distribution = .fillEqually
+        return stack
     }()
     
     override func viewDidLoad() {
@@ -74,7 +83,7 @@ final class WindowVoiceViewController: UIViewController, ConfigUI {
         setupNavigationBar()
         addComponents()
         setConstraints()
-        speechButton.setup(model: speechButtonViewModel)
+        yesButton.setup(model: yesButtonViewModel)
     }
 
     func setupNavigationBar() {
@@ -91,9 +100,10 @@ final class WindowVoiceViewController: UIViewController, ConfigUI {
     }
     
     func addComponents() {
-        [titleLabel, doorWithHolesImageView, speechButton].forEach {
+        [titleLabel, doorWithHolesImageView, buttonHorizontalStack].forEach {
             view.addSubview($0)
         }
+        [yesButton, noButton].forEach(buttonHorizontalStack.addArrangedSubview)
     }
     
     func setConstraints() {
@@ -103,24 +113,28 @@ final class WindowVoiceViewController: UIViewController, ConfigUI {
         }
         
         doorWithHolesImageView.snp.makeConstraints {
-            $0.top.equalToSuperview().offset(324)
-            $0.left.right.equalToSuperview().inset(81)
-            $0.bottom.equalToSuperview().offset(-148)
+            $0.top.equalToSuperview().offset(256)
+            $0.left.right.equalToSuperview().inset(51)
+            $0.bottom.equalToSuperview().inset(118)
         }
         
-        speechButton.setup(model: speechButtonViewModel)
+        yesButton.setup(model: yesButtonViewModel)
+        noButton.setup(model: noButtonViewModel)
         
-        speechButton.snp.makeConstraints {
+        buttonHorizontalStack.snp.makeConstraints {
             $0.left.right.equalToSuperview().inset(Constants.Button.buttonPadding)
             $0.bottom.equalToSuperview().inset(Constants.Button.buttonPadding * 2)
-            $0.height.equalTo(72)
         }
     }
     
     func setupAccessibility() {
-        navigationItem.accessibilityElements = [leftBarButtonItem, navigationTitle]
-        view.accessibilityElements = [titleLabel, speechButton]
-        leftBarButtonItem.accessibilityLabel = "내 책장"
+        let leftBarButtonElement = setupLeftBackButtonItemAccessibility(label: "내 책장")
+        view.accessibilityElements = [titleLabel, yesButton, noButton, leftBarButtonElement]
+        titleLabel.accessibilityLabel = """
+                                        문 바끌 확인해보니 어때?
+                                        엄마일까, 호랑이일까?
+                                        문을 열어줘도 될까?
+                                        """
     }
     
     @objc

--- a/Codingdong-iOS/Codingdong-iOS/Presentation/SM_Concept3/ViewController/OnuiiViewController.swift
+++ b/Codingdong-iOS/Codingdong-iOS/Presentation/SM_Concept3/ViewController/OnuiiViewController.swift
@@ -42,23 +42,21 @@ final class OnuiiViewController: UIViewController, ConfigUI {
     private let contentLabel: UILabel = {
        let label = UILabel()
         label.text = """
-         세번째 이야기
+         오누이는 호랑이를 피하기 위해 동아줄을 붙잡고 올라갔어.
 
-         오누이는 호랑이를 피하기 위해 동아줄을 붙잡고 올라갔어요.
+         하지만, 어린 오누이가 올라가기에는 너무 힘든 것 같아.
 
-         하지만, 어린 오누이는 동아줄을 잡고 올라가기가 너무 힘들었어요.
-
-         오누이가 무사히 올라갈 수 있도록 도와주세요!
+         오누이가 무사히 올라갈 수 있도록 도와줘!
          """
         label.textColor = .gs10
         label.font = FontManager.body()
         label.numberOfLines = 0
-        label.lineBreakMode = .byCharWrapping
+        label.lineBreakMode = .byWordWrapping
         return label
     }()
     
     private let rescueButton = CommonButton()
-    private lazy var rescuButtonViewModel = CommonbuttonModel(title: "오누이 구출하기", font: FontManager.textbutton(), titleColor: .primary1, backgroundColor: .primary2) {[weak self] in
+    private lazy var rescuButtonViewModel = CommonbuttonModel(title: "오누이 구출하기", font: FontManager.textbutton(), titleColor: .primary1, backgroundColor: .primary2, height: 72) {[weak self] in
         
         self?.navigationController?.pushViewController(RopeViewController(), animated: false)
     }
@@ -66,10 +64,16 @@ final class OnuiiViewController: UIViewController, ConfigUI {
     // MARK: - View Init
     override func viewDidLoad() {
         super.viewDidLoad()
+        view.backgroundColor = .gs90
         setupNavigationBar()
         addComponents()
         setConstraints()
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
         setupAccessibility()
+        navigationController?.navigationBar.accessibilityElementsHidden = true
     }
     
     func setupNavigationBar() {
@@ -91,22 +95,21 @@ final class OnuiiViewController: UIViewController, ConfigUI {
     func setConstraints() {
         contentLabel.snp.makeConstraints {
             $0.top.equalTo(naviLine.snp.bottom).offset(Constants.Button.buttonPadding)
-            $0.left.equalToSuperview().offset(Constants.Button.buttonPadding)
-            $0.right.equalToSuperview().offset(-Constants.Button.buttonPadding)
+            $0.left.right.equalToSuperview().inset(Constants.Button.buttonPadding)
         }
         
         rescueButton.setup(model: rescuButtonViewModel)
         
         rescueButton.snp.makeConstraints {
-            $0.left.right.equalToSuperview().inset(16)
-            $0.bottom.equalToSuperview().offset(-Constants.Button.buttonPadding*2)
+            $0.left.right.equalToSuperview().inset(Constants.Button.buttonPadding)
+            $0.bottom.equalToSuperview().inset(Constants.Button.buttonPadding*2)
         }
     }
     
     func setupAccessibility() {
-        navigationItem.accessibilityElements = [leftBarButtonItem, navigationTitle]
-        view.accessibilityElements = [contentLabel, rescueButton]
-        leftBarButtonItem.accessibilityLabel = "내 책장"
+        let leftBarButtonElement = setupLeftBackButtonItemAccessibility(label: "내 책장")
+        let naviTitleElement = setupNavigationTitleAccessibility(label: navigationTitle.text ?? "타이틀 없음")
+        view.accessibilityElements = [naviTitleElement, contentLabel, rescueButton, leftBarButtonElement]
     }
     
     @objc func popThisView() {

--- a/Codingdong-iOS/Codingdong-iOS/Presentation/SM_Concept3/ViewController/RepeatConceptViewController.swift
+++ b/Codingdong-iOS/Codingdong-iOS/Presentation/SM_Concept3/ViewController/RepeatConceptViewController.swift
@@ -6,7 +6,6 @@
 //
 
 import UIKit
-import Log
 import Combine
 
 final class RepeatConceptViewController: UIViewController, ConfigUI {
@@ -39,11 +38,11 @@ final class RepeatConceptViewController: UIViewController, ConfigUI {
     
     private let titleLabel: UILabel = {
         let label = UILabel()
-        label.text = "해님달님의 세 번째 개념"
+        label.text = "마지막 코딩 간식이야."
         label.font = FontManager.body()
         label.textColor = .gs10
         label.numberOfLines = 0
-        label.lineBreakMode = .byCharWrapping
+        label.lineBreakMode = .byWordWrapping
         return label
     }()
     
@@ -52,20 +51,25 @@ final class RepeatConceptViewController: UIViewController, ConfigUI {
     
     // MARK: - ViewModel
     private var viewModel = OnuiiViewModel()
-    private var cardViewModel = CardViewModel(title: "거듭하기", content: "흔들기 동작을 반복하면서 오누이가 동아줄을 오를 수 있게 도와줬어요.", cardImage: "sm_concept3")
+    private var cardViewModel = CardViewModel(title: "거듭하기 젤리", content: "흔들기 동작을 반복하면서 오누이가 동아줄을 오를 수 있게 도와줬어. 고마워!", cardImage: "sm_concept3")
     
     private lazy var nextButtonViewModel = CommonbuttonModel(title: "복습하기", font: FontManager.textbutton(), titleColor: .primary1, backgroundColor: .gs10, height: 72) {[weak self] in
-//        self?.viewModel.moveOn()
         self?.navigationController?.pushViewController(ReviewViewController(), animated: false)
     }
     
     // MARK: - View initializer
     override func viewDidLoad() {
         super.viewDidLoad()
-        setupAccessibility()
+        view.backgroundColor = .gs90
         setupNavigationBar()
         addComponents()
         setConstraints()
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        setupAccessibility()
+        navigationController?.navigationBar.accessibilityElementsHidden = true
     }
     
     func setupNavigationBar() {
@@ -89,13 +93,12 @@ final class RepeatConceptViewController: UIViewController, ConfigUI {
     func setConstraints() {
         titleLabel.snp.makeConstraints {
             $0.top.equalTo(naviLine.snp.bottom).offset(padding)
-            $0.left.equalToSuperview().offset(padding)
-            $0.right.equalToSuperview().offset(-padding)
+            $0.left.right.equalToSuperview().inset(padding)
         }
         
         cardView.snp.makeConstraints {
             $0.top.equalTo(titleLabel.snp.bottom).offset(50)
-            $0.bottom.equalToSuperview().offset(-142)
+            $0.bottom.equalToSuperview().inset(142)
             $0.left.right.equalToSuperview()
         }
         
@@ -106,9 +109,9 @@ final class RepeatConceptViewController: UIViewController, ConfigUI {
     }
     
     func setupAccessibility() {
-        navigationItem.accessibilityElements = [leftBarButtonItem, navigationTitle]
-        view.accessibilityElements = [titleLabel, cardView, nextButton]
-        leftBarButtonItem.accessibilityLabel = "내 책장"
+        let leftBarButtonElement = setupLeftBackButtonItemAccessibility(label: "내 책장")
+        let naviTitleElement = setupNavigationTitleAccessibility(label: navigationTitle.text ?? "타이틀 없음")
+        view.accessibilityElements = [naviTitleElement, titleLabel, cardView, nextButton, leftBarButtonElement]
     }
 
     @objc func popThisView() {

--- a/Codingdong-iOS/Codingdong-iOS/Presentation/SM_Concept3/ViewController/RopeViewController.swift
+++ b/Codingdong-iOS/Codingdong-iOS/Presentation/SM_Concept3/ViewController/RopeViewController.swift
@@ -44,7 +44,7 @@ final class RopeViewController: UIViewController, ConfigUI {
         label.textColor = .gs10
         label.font = FontManager.body()
         label.numberOfLines = 0
-        label.lineBreakMode = .byCharWrapping
+        label.lineBreakMode = .byWordWrapping
         return label
     }()
     

--- a/Codingdong-iOS/Codingdong-iOS/Presentation/SM_Concept3/ViewController/RopeViewController.swift
+++ b/Codingdong-iOS/Codingdong-iOS/Presentation/SM_Concept3/ViewController/RopeViewController.swift
@@ -40,7 +40,7 @@ final class RopeViewController: UIViewController, ConfigUI {
     
     private let contentLabel: UILabel = {
        let label = UILabel()
-        label.text = "기기를 100번 흔들어 주세요!"
+        label.text = "휴대폰을 꽉 붙잡고 100번 흔들어보자!"
         label.textColor = .gs10
         label.font = FontManager.body()
         label.numberOfLines = 0
@@ -59,11 +59,17 @@ final class RopeViewController: UIViewController, ConfigUI {
     // MARK: - View Init
     override func viewDidLoad() {
         super.viewDidLoad()
+        view.backgroundColor = .gs90
         setupNavigationBar()
         addComponents()
         setConstraints()
-        setupAccessibility()
         countShake()
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        setupAccessibility()
+        navigationController?.navigationBar.accessibilityElementsHidden = true
     }
     
     func setupNavigationBar() {
@@ -96,11 +102,10 @@ final class RopeViewController: UIViewController, ConfigUI {
     }
     
     func setupAccessibility() {
-        navigationItem.accessibilityElements = [leftBarButtonItem, navigationTitle]
-        view.accessibilityElements = [contentLabel, ropeImage]
-        leftBarButtonItem.accessibilityLabel = "내 책장"
-        ropeImage.isAccessibilityElement = true
-        ropeImage.accessibilityLabel = "동아줄"
+        let leftBarButtonElement = setupLeftBackButtonItemAccessibility(label: "내 책장")
+        view.accessibilityElements = [contentLabel, ropeImage, leftBarButtonElement]
+        ropeImage.accessibilityLabel = "하늘에서 내려온 동아줄이야. 얼른 붙잡고 흔들어서 올라가야해!"
+        ropeImage.accessibilityTraits = .none
     }
     
     @objc func popThisView() {

--- a/Codingdong-iOS/Codingdong-iOS/Presentation/SM_Concept3/ViewController/SunMoonOnuiiViewController.swift
+++ b/Codingdong-iOS/Codingdong-iOS/Presentation/SM_Concept3/ViewController/SunMoonOnuiiViewController.swift
@@ -7,7 +7,6 @@
 
 import UIKit
 import Combine
-import Log
 
 final class SunMoonOnuiiViewController: UIViewController, ConfigUI {
 
@@ -39,13 +38,14 @@ final class SunMoonOnuiiViewController: UIViewController, ConfigUI {
     private let contentLabel: UILabel = {
        let label = UILabel()
         label.text = """
-        오누이는 동아줄을 올라
-        해와 달이 되었답니다.
+        고마워! 덕분에 오누이는 동아줄을 타고 하늘로 올라갔어.
+        하늘로 올라간 오누이는 해와 달이 되어서
+        너를 밝게 비춰주고 싶대.
         """
         label.textColor = .gs10
         label.font = FontManager.body()
         label.numberOfLines = 0
-        label.lineBreakMode = .byCharWrapping
+        label.lineBreakMode = .byWordWrapping
         return label
     }()
     
@@ -64,18 +64,17 @@ final class SunMoonOnuiiViewController: UIViewController, ConfigUI {
     // MARK: - View Init
     override func viewDidLoad() {
         super.viewDidLoad()
-        setupAccessibility()
+        view.backgroundColor = .gs90
         setupNavigationBar()
         addComponents()
         setConstraints()
-//        playAnimationWithVoiceOver()
-        if UIAccessibility.isVoiceOverRunning {
-            NotificationCenter.default.addObserver(self, selector: #selector(voiceOverFocusChanged), name: UIAccessibility.elementFocusedNotification, object: nil)
-        } else {
-            DispatchQueue.main.asyncAfter(deadline: .now() + 4.5) {
-//                LottieManager.shared.playWithProgressTimeAnimation(inView: self.lottieView, from: 0, to: 0.8, completion: nil)
-            }
-        }
+        playAnimationWithVoiceOver()
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        setupAccessibility()
+        navigationController?.navigationBar.accessibilityElementsHidden = true
     }
     
     deinit {
@@ -110,17 +109,24 @@ final class SunMoonOnuiiViewController: UIViewController, ConfigUI {
         
         nextButton.setup(model: nextButtonViewModel)
         nextButton.snp.makeConstraints {
-            $0.left.equalToSuperview().offset(Constants.Button.buttonPadding)
-            $0.right.equalToSuperview().offset(-Constants.Button.buttonPadding)
-            $0.bottom.equalToSuperview().offset(-Constants.Button.buttonPadding*2)
+            $0.left.right.equalToSuperview().inset(Constants.Button.buttonPadding)
+            $0.bottom.equalToSuperview().inset(Constants.Button.buttonPadding*2)
         }
         
     }
     
     func setupAccessibility() {
-        navigationItem.accessibilityElements = [leftBarButtonItem, navigationTitle]
-        view.accessibilityElements = [contentLabel, nextButton]
-        leftBarButtonItem.accessibilityLabel = "내 책장"
+        let leftBarButtonElement = setupLeftBackButtonItemAccessibility(label: "내 책장")
+        view.accessibilityElements = [contentLabel, nextButton, leftBarButtonElement]
+        contentLabel.accessibilityLabel = """
+                                        고마워!
+                                        
+                                        덕분에 오누이는 동아줄을 타고 하늘로 올라갔어.
+                                        
+                                        하늘로 올라간 오누이는 해와 달이 되어서
+                                        
+                                        너를 밝게 비춰주고싶대.
+                                        """
     }
     
 }
@@ -136,7 +142,7 @@ extension SunMoonOnuiiViewController {
             NotificationCenter.default.addObserver(self, selector: #selector(voiceOverFocusChanged), name: UIAccessibility.elementFocusedNotification, object: nil)
         } else {
             DispatchQueue.main.asyncAfter(deadline: .now() + 4.5) {
-//                LottieManager.shared.playWithProgressTimeAnimation(inView: self.lottieView, from: 0, to: 0.8, completion: nil)
+                LottieManager.shared.playAnimation(inView: self.lottieView, completion: nil)
             }
         }
     }

--- a/Codingdong-iOS/Codingdong-iOS/Presentation/SM_Concept3/ViewController/TeachingRepeatViewController.swift
+++ b/Codingdong-iOS/Codingdong-iOS/Presentation/SM_Concept3/ViewController/TeachingRepeatViewController.swift
@@ -38,11 +38,11 @@ final class TeachingRepeatViewController: UIViewController, ConfigUI {
     private let contentLabel: UILabel = {
        let label = UILabel()
         label.text = """
-         지금까지 10번 흔들었어요.
+         지금까지 10번 흔들었어.
 
-         힘든가요?
+         어때, 힘들지 않아?
 
-         반복문을 사용하면, 편하게 반복할 수 있어요!
+         반복문을 사용하면, 원하는 횟수만큼 자동으로 반복할 수 있어!
          """
         label.textColor = .gs10
         label.font = FontManager.body()
@@ -55,6 +55,7 @@ final class TeachingRepeatViewController: UIViewController, ConfigUI {
        let imageView = UIImageView()
         imageView.contentMode = .scaleAspectFit
         imageView.image = UIImage(named: "sm_repeat1")
+        imageView.isAccessibilityElement = true
         return imageView
     }()
     
@@ -77,11 +78,16 @@ final class TeachingRepeatViewController: UIViewController, ConfigUI {
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .gs90
-        setupAccessibility()
         setupNavigationBar()
         addComponents()
         setConstraints()
         playAnimationWithVoiceOver()
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        setupAccessibility()
+        navigationController?.navigationBar.accessibilityElementsHidden = true
     }
     
     func setupNavigationBar() {
@@ -118,7 +124,7 @@ final class TeachingRepeatViewController: UIViewController, ConfigUI {
         tenTimesImage.snp.makeConstraints {
             $0.centerY.equalTo(repeatImage)
         }
-//    
+        
         nextButton.setup(model: nextButtonViewModel)
         nextButton.snp.makeConstraints {
             $0.top.equalTo(repeatImage.snp.bottom).offset(110)
@@ -128,18 +134,17 @@ final class TeachingRepeatViewController: UIViewController, ConfigUI {
     }
     
     func setupAccessibility() {
-        navigationItem.accessibilityElements = [leftBarButtonItem, navigationTitle]
-        view.accessibilityElements = [contentLabel, repeatImage, nextButton]
-        leftBarButtonItem.accessibilityLabel = "내 책장"
+        let leftBarButtonElement = setupLeftBackButtonItemAccessibility(label: "내 책장")
+        view.accessibilityElements = [contentLabel, repeatImage, nextButton, leftBarButtonElement]
+        
         contentLabel.accessibilityLabel = """
-                지금까지 열번 흔들었어요.
+                                         지금까지 열번 흔들었어.
 
-                힘든가요?
+                                         어때, 힘들지 않아?
 
-                반복문을 사용하면, 편하게 반복할 수 있어요!
-                """
-        repeatImage.isAccessibilityElement = true
-        repeatImage.accessibilityLabel = "열번 흔들기를 열번 반복하는걸 보여주는 이미지"
+                                         반복문을 사용하면, 원하는 횟수만큼 자동으로 반복할 수 있어!
+                                         """
+        repeatImage.accessibilityLabel = "그럼 100번 흔드는 것도 금방 할 수 있겠지?"
         repeatImage.accessibilityTraits = .none
     }
     

--- a/Codingdong-iOS/Codingdong-iOS/Presentation/SM_Concept3/ViewController/TeachingRepeatViewController.swift
+++ b/Codingdong-iOS/Codingdong-iOS/Presentation/SM_Concept3/ViewController/TeachingRepeatViewController.swift
@@ -108,7 +108,7 @@ final class TeachingRepeatViewController: UIViewController, ConfigUI {
     
     func setConstraints() {
         contentLabel.snp.makeConstraints {
-            $0.top.equalTo(naviLine.snp.bottom).offset(16)
+            $0.top.equalTo(naviLine.snp.bottom).offset(Constants.Button.buttonPadding)
             $0.left.right.equalToSuperview().inset(16)
         }
         
@@ -127,8 +127,8 @@ final class TeachingRepeatViewController: UIViewController, ConfigUI {
         
         nextButton.setup(model: nextButtonViewModel)
         nextButton.snp.makeConstraints {
-            $0.top.equalTo(repeatImage.snp.bottom).offset(110)
-            $0.left.right.equalToSuperview().inset(16)
+            $0.left.right.equalToSuperview().inset(Constants.Button.buttonPadding)
+            $0.bottom.equalToSuperview().inset(Constants.Button.buttonPadding * 2)
         }
 
     }

--- a/Codingdong-iOS/Codingdong-iOS/Presentation/SM_Concept3/ViewController/TeachingRepeatViewController.swift
+++ b/Codingdong-iOS/Codingdong-iOS/Presentation/SM_Concept3/ViewController/TeachingRepeatViewController.swift
@@ -47,7 +47,7 @@ final class TeachingRepeatViewController: UIViewController, ConfigUI {
         label.textColor = .gs10
         label.font = FontManager.body()
         label.numberOfLines = 0
-        label.lineBreakMode = .byCharWrapping
+        label.lineBreakMode = .byWordWrapping
         return label
     }()
     

--- a/Codingdong-iOS/Codingdong-iOS/Presentation/SM_Ending/ViewController/ReviewViewController.swift
+++ b/Codingdong-iOS/Codingdong-iOS/Presentation/SM_Ending/ViewController/ReviewViewController.swift
@@ -13,9 +13,9 @@ final class ReviewViewController: UIViewController, ConfigUI {
     // 뷰 전체 model, cellModel
     // MARK: - ViewModel
     private var viewModel = ReviewViewModel()
-    private var cellModels: [CardViewModel] = [.init(title: "만약에 : 조건문", content: "만약에는 코딩의 ‘조건문’에 해당돼요. 조건문은 정해진 상황에 따라 다른 동작이 수행되게 만들 수 있어요.", cardImage: "sm_review1"),
-        .init(title: "그리고 : 연산자", content: "그리고는 코딩의 ‘연산자’에 해당돼요. 연산자는 조건의 ‘참'과 ‘거짓'을 판단해요.", cardImage: "sm_review2"),
-        .init(title: "거듭하기 : 반복문", content: "거듭하기는 코딩의 ‘반복문’에 해당돼요. 반복문을 사용하여 같은 동작이 반복되도록 만들 수 있어요.", cardImage: "sm_review3")]
+    private var cellModels: [CardViewModel] = [.init(title: "만약에 : 조건문", content: "만약에는 코딩의 ‘조건문’과 같아. 조건문은 정해진 상황에 따라 다른 동작을 하게 만들 수 있어.", cardImage: "sm_review1"),
+        .init(title: "그리고 : 연산자", content: "그리고는 코딩의 ‘연산자’와 같아. 구멍 세개를 보고 호랑이인 걸 알 수 있었지? 이처럼 여러 조건이 같을 때 정답이 되는 개념이야.", cardImage: "sm_review2"),
+        .init(title: "거듭하기 : 반복문", content: "거듭하기는 코딩의 ‘반복문’과 같아. 반복문을 사용하면 같은 동작을 원하는 만큼 자동으로 할 수 있어.", cardImage: "sm_review3")]
     
     // MARK: - Components
     private let naviLine: UIView = {
@@ -44,7 +44,7 @@ final class ReviewViewController: UIViewController, ConfigUI {
     
     private let contentLabel: UILabel = {
         let label = UILabel()
-        label.text = "해님달님에서 세 가지 개념을 배웠어요"
+        label.text = "해님달님에서 세 가지 개념을 배웠어."
         label.textColor = .gs10
         label.numberOfLines = 0
         label.font = FontManager.body()
@@ -82,11 +82,16 @@ final class ReviewViewController: UIViewController, ConfigUI {
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .gs90
-        setupAccessibility()
         setupNavigationBar()
         addComponents()
         setConstraints()
         setupPageControl()
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        setupAccessibility()
+        navigationController?.navigationBar.accessibilityElementsHidden = true
     }
     
     func setupNavigationBar() {
@@ -139,28 +144,26 @@ final class ReviewViewController: UIViewController, ConfigUI {
     func setConstraints() {
         contentLabel.snp.makeConstraints {
             $0.top.equalTo(naviLine.snp.bottom).offset(padding)
-            $0.left.equalToSuperview().offset(padding)
-            $0.right.equalToSuperview().offset(-padding)
+            $0.left.right.equalToSuperview().inset(padding)
         }
         
         reviewCollectionView.snp.makeConstraints {
             $0.top.equalTo(contentLabel.snp.bottom).offset(padding)
             $0.left.right.equalToSuperview()
-            $0.bottom.equalToSuperview().offset(-142)
+            $0.bottom.equalToSuperview().inset(142)
         }
         nextButton.setup(model: nextButtonViewModel)
         nextButton.snp.makeConstraints {
             $0.top.equalTo(reviewCollectionView.snp.bottom).offset(38)
-            $0.left.equalToSuperview().offset(padding)
-            $0.right.equalToSuperview().offset(-padding)
-            $0.bottom.equalToSuperview().offset(-padding * 2)
+            $0.left.right.equalToSuperview().inset(padding)
+            $0.bottom.equalToSuperview().inset(padding * 2)
         }
     }
     
     func setupAccessibility() {
-        navigationItem.accessibilityElements = [leftBarButtonItem, navigationTitle]
-        view.accessibilityElements = [contentLabel, reviewCollectionView, nextButton]
-        leftBarButtonItem.accessibilityLabel = "내 책장"
+        let leftBarButtonElement = setupLeftBackButtonItemAccessibility(label: "내 책장")
+        let naviTitleElement = setupNavigationTitleAccessibility(label: navigationTitle.text ?? "타이틀 없음")
+        view.accessibilityElements = [naviTitleElement, contentLabel, reviewCollectionView, nextButton, leftBarButtonElement]
     }
     
     @objc private func popThisView() {

--- a/Codingdong-iOS/Codingdong-iOS/Presentation/SM_Ending/ViewController/ReviewViewController.swift
+++ b/Codingdong-iOS/Codingdong-iOS/Presentation/SM_Ending/ViewController/ReviewViewController.swift
@@ -48,7 +48,7 @@ final class ReviewViewController: UIViewController, ConfigUI {
         label.textColor = .gs10
         label.numberOfLines = 0
         label.font = FontManager.body()
-        label.lineBreakMode = .byCharWrapping
+        label.lineBreakMode = .byWordWrapping
         return label
     }()
     

--- a/Codingdong-iOS/Codingdong-iOS/Presentation/SM_Intro/ViewController/SunAndMoonIntroViewController.swift
+++ b/Codingdong-iOS/Codingdong-iOS/Presentation/SM_Intro/ViewController/SunAndMoonIntroViewController.swift
@@ -46,7 +46,7 @@ final class SunAndMoonIntroViewController: UIViewController, ConfigUI {
         label.font = FontManager.body()
         label.textColor = .gs10
         label.numberOfLines = 0
-        label.lineBreakMode = .byCharWrapping
+        label.lineBreakMode = .byWordWrapping
         return label
     }()
     

--- a/Codingdong-iOS/Codingdong-iOS/Presentation/SM_Intro/ViewController/TigerEncountViewController.swift
+++ b/Codingdong-iOS/Codingdong-iOS/Presentation/SM_Intro/ViewController/TigerEncountViewController.swift
@@ -53,7 +53,7 @@ final class TigerEncountViewController: UIViewController, ConfigUI {
         label.font = FontManager.body()
         label.textColor = .gs10
         label.numberOfLines = 0
-        label.lineBreakMode = .byCharWrapping
+        label.lineBreakMode = .byWordWrapping
         return label
     }()
     


### PR DESCRIPTION
<!--제목 작성 방법 -->
<!--[FEAT/SETTING/DESIGN/FIX/REFACTOR/DOCS] 관련 내용 기재 -->

## 🛠️ 작업 내용
- #127 
- #129 의 후속 작업입니다.
<!-- - #이슈번호 -->


<br/>

## 👀 소개
- 변경된 UIAccessibility 사항을 이전 작업분 외 나머지 화면에도 적용

- 좀 더 아동 친화적인 문구로 수정
- 화면 여백이 여유로운 뷰의 경우 .byCharWrapping에서 .byWordWrapping으로 변경
- 떡 흔들기 뷰에서, 떡 이미지에 `UIAccessibilityLabel` 추가
  - ```ttekkStackView.accessibilityLabel = "떡이 \(ttekks.count - 1)개 남았어. 얼른 호랑이한테 떡을 주자!"```
- 동아줄 뷰에서, 동아줄 이미지에 `UIAccessibilityLabel` 추가
  - ```ropeImage.accessibilityLabel = "하늘에서 내려온 동아줄이야. 얼른 붙잡고 흔들어서 올라가야해!"``` 
- 창문 뷰 호랑이 구멍 순서 수정 및 구멍 확대 후 UIAccessibilityLabel 변경
  - ```tigerHandHoleAnimationView.lottieView.accessibilityLabel = "손톱이 날카로운 호랑이 손"```
- 떡꼬치 뷰 레이아웃 수정

<!-- 구현된 내용(스샷 포함), 사용법, 참고 자료, 함께 논의하고 싶은 내용 등을 자유롭게 기재 -->

<br/>

## ✋ 잠깐만! 자가 체크

- [x]  나는 올바른 브랜치에서 작업했나요?
- [x]  머지하려는 브랜치의 방향이 정확한가요? 혹쉬 지금 main으로 머지하려던 건 아니겠죠?
- [x]  PR에 내가 작업한 내용을 모두 기재했나요? 설마 귀찮다고 그냥 넘어가려던 건 아니겠죠?
- [x]  스스로 self-review는 했나요?
- [x]  내 코드에 대한 책임은 나에게 있다! PR 보냈다고 끝이 아니란 사실, 이미 잘 알고 있죠?
